### PR TITLE
Multiple improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --no-cache wget && \
     wget https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip && \
     unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION} && \
     cd /usr/bin && ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}/bin/sonar-scanner sonar-scanner && \
-    apk del wget
+    apk del wget && \
+    ln -s /usr/bin/sonar-scanner-run.sh /bin/gitlab-sonar-scanner
 
 COPY sonar-scanner-run.sh /usr/bin

--- a/LICENSE
+++ b/LICENSE
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    Gitlab-sonar-scanner  Copyright (C) 2017-2018 Alvarium.io
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/Readme.md
+++ b/Readme.md
@@ -18,10 +18,10 @@ sonarqube:
   stage: analysis
   image: ciricihq/gitlab-sonar-scanner
   variables:
-    SONAR_URL: "http://your.sonarqube.server:9000"
-    SONAR_ANALYSIS_MODE: "issues"
+    SONAR_URL: http://your.sonarqube.server
+    SONAR_ANALYSIS_MODE: issues
   script:
-  - /usr/bin/sonar-scanner-run.sh
+  - gitlab-sonar-scanner
 ~~~
 
 Remember to also create a `sonar-project.properties` file:
@@ -55,10 +55,10 @@ sonarqube-reports:
   stage: analysis
   image: ciricihq/gitlab-sonar-scanner
   variables:
-    SONAR_URL: "http://your.sonarqube.server:9000"
-    SONAR_ANALYSIS_MODE: "publish"
+    SONAR_URL: http://your.sonarqube.server
+    SONAR_ANALYSIS_MODE: publish
   script:
-  - /usr/bin/sonar-scanner-run.sh
+  - gitlab-sonar-scanner
 ~~~
 
 Note how we've changed from `issues` to `publish` in `SONAR_ANALYSIS_MODE`.
@@ -73,19 +73,19 @@ sonarqube:
   stage: analysis
   image: ciricihq/gitlab-sonar-scanner
   variables:
-    SONAR_URL: "http://your.sonarqube.server:9000"
-    SONAR_ANALYSIS_MODE: "issues"
+    SONAR_URL: http://your.sonarqube.server
+    SONAR_ANALYSIS_MODE: issues
   script:
-  - /usr/bin/sonar-scanner-run.sh
+  - sonar-gitlab-scanner
 
 sonarqube-reports:
   stage: analysis
   image: ciricihq/gitlab-sonar-scanner
   variables:
-    SONAR_URL: "http://your.sonarqube.server:9000"
-    SONAR_ANALYSIS_MODE: "publish"
+    SONAR_URL: http://your.sonarqube.server
+    SONAR_ANALYSIS_MODE: publish
   script:
-  - /usr/bin/sonar-scanner-run.sh
+  - sonar-gitlab-scanner
 ~~~
 
 Available environment variables

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,6 @@ sonarqube:
   image: ciricihq/gitlab-sonar-scanner
   variables:
     SONAR_URL: "http://your.sonarqube.server:9000"
-    SONAR_PROJECT_VERSION: "$CI_BUILD_ID"
     SONAR_ANALYSIS_MODE: "issues"
   script:
   - /usr/bin/sonar-scanner-run.sh
@@ -30,7 +29,6 @@ Remember to also create a `sonar-project.properties` file:
 ~~~conf
 sonar.projectKey=your-project-key
 sonar.exclusions=node_modules/**,coverage/**
-sonar.projectVersion=1.0
 
 sonar.sources=.
 
@@ -58,7 +56,6 @@ sonarqube-reports:
   image: ciricihq/gitlab-sonar-scanner
   variables:
     SONAR_URL: "http://your.sonarqube.server:9000"
-    SONAR_PROJECT_VERSION: "$CI_BUILD_ID"
     SONAR_ANALYSIS_MODE: "publish"
   script:
   - /usr/bin/sonar-scanner-run.sh
@@ -77,7 +74,6 @@ sonarqube:
   image: ciricihq/gitlab-sonar-scanner
   variables:
     SONAR_URL: "http://your.sonarqube.server:9000"
-    SONAR_PROJECT_VERSION: "$CI_BUILD_ID"
     SONAR_ANALYSIS_MODE: "issues"
   script:
   - /usr/bin/sonar-scanner-run.sh
@@ -87,7 +83,6 @@ sonarqube-reports:
   image: ciricihq/gitlab-sonar-scanner
   variables:
     SONAR_URL: "http://your.sonarqube.server:9000"
-    SONAR_PROJECT_VERSION: "$CI_BUILD_ID"
     SONAR_ANALYSIS_MODE: "publish"
   script:
   - /usr/bin/sonar-scanner-run.sh

--- a/Readme.md
+++ b/Readme.md
@@ -109,8 +109,18 @@ Can be checked in the official documentation: https://docs.sonarqube.org/display
 - `CI_BUILD_REF`: See [ci/variables][variables]
 - `CI_BUILD_REF_NAME`: See [ci/variables][variables]
 
+LICENSE
+=======
+
+All the code contained in this repository is licensed under a GNU-GPLv3 license.
+
+Copyright Alvarium.io 2017-2018.
+
+See [LICENSE][] for more details
+
 [sonar gitlab plugin]: https://github.com/gabrie-allaigre/sonar-gitlab-plugin
 [variables]: https://docs.gitlab.com/ce/ci/variables
 [docker hub]: https://hub.docker.com/r/ciricihq/gitlab-sonar-scanner
+[LICENSE]: ./LICENSE
 
 [docker hub svg]: https://img.shields.io/docker/pulls/ciricihq/gitlab-sonar-scanner.svg

--- a/Readme.md
+++ b/Readme.md
@@ -49,14 +49,10 @@ sonarqube-reports:
     SONAR_PROJECT_VERSION: "$CI_BUILD_ID"
     SONAR_ANALYSIS_MODE: "publish"
   script:
-  - unset CI_BUILD_REF && /usr/bin/sonar-scanner-run.sh
+  - /usr/bin/sonar-scanner-run.sh
 ~~~
 
-Note how we've changed from `issues` to `publish` in `SONAR_ANALYSIS_MODE` +
-we've added `unset CI_BUILD_REF &&` before the `sonar-sacnner-run.sh` command.
-
-Unsetting the `CI_BUILD_REF` before running the scanner will disable the gitlab
-plugin and thus allow you to publish the results to sonarqube.
+Note how we've changed from `issues` to `publish` in `SONAR_ANALYSIS_MODE`.
 
 ### Full .gitlab-ci.yaml with preview + publish
 
@@ -82,7 +78,7 @@ sonarqube-reports:
     SONAR_PROJECT_VERSION: "$CI_BUILD_ID"
     SONAR_ANALYSIS_MODE: "publish"
   script:
-  - unset CI_BUILD_REF && /usr/bin/sonar-scanner-run.sh
+  - /usr/bin/sonar-scanner-run.sh
 ~~~
 
 ## Available environment variables

--- a/Readme.md
+++ b/Readme.md
@@ -110,6 +110,21 @@ Can be checked in the official documentation: https://docs.sonarqube.org/display
 - `CI_BUILD_REF`: See [ci/variables][variables]
 - `CI_BUILD_REF_NAME`: See [ci/variables][variables]
 
+### Defining custom sonar-scanner options
+
+You can pass any additional option to the `gitlab-sonar-scanner` binnary, if needed:
+
+~~~yaml
+sonarqube-reports:
+  image: ciricihq/gitlab-sonar-scanner
+  variables:
+    SONAR_URL: http://your.sonarqube.server
+    SONAR_ANALYSIS_MODE: publish
+  script:
+  - sonar-gitlab-scanner -Dsonar.custom.param=whatever -Dsonar.custom.param2=whichever
+~~~
+
+
 LICENSE
 =======
 

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,18 @@ sonarqube:
   - /usr/bin/sonar-scanner-run.sh
 ```
 
+Remember to also create a `sonar-project.properties` file:
+
+~~~conf
+sonar.projectKey=your-project-key
+sonar.exclusions=node_modules/**,coverage/**
+sonar.projectVersion=1.0
+
+sonar.sources=.
+
+sonar.gitlab.project_id=git@your-git-repo.git
+~~~
+
 Before running the analysis stage you should ensure to have the project created
 in your sonarqube + having it configured to use the gitlab plugin (specifying the
 gitlab repo url).

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Using it in your gitlab projects
 
 Add the next stage to your `.gitlab-ci.yml`.
 
-```yaml
+~~~yaml
 stages:
 - analysis
 
@@ -22,7 +22,7 @@ sonarqube:
     SONAR_ANALYSIS_MODE: "issues"
   script:
   - /usr/bin/sonar-scanner-run.sh
-```
+~~~
 
 Remember to also create a `sonar-project.properties` file:
 
@@ -88,7 +88,8 @@ sonarqube-reports:
   - /usr/bin/sonar-scanner-run.sh
 ~~~
 
-## Available environment variables
+Available environment variables
+-------------------------------
 
 Can be checked in the official documentation: https://docs.sonarqube.org/display/SONARQUBE43/Analysis+Parameters
 

--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -62,6 +62,9 @@ if [ ! -z $SONAR_ANALYSIS_MODE ]; then
   if [ $SONAR_ANALYSIS_MODE="preview" ]; then
     COMMAND="$COMMAND -Dsonar.issuesReport.console.enable=true"
   fi
+  if [ $SONAR_ANALYSIS_MODE="publish" ]; then
+    unset CI_BUILD_REF
+  fi
 fi
 
 $COMMAND

--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -8,6 +8,18 @@ URL=$SONAR_URL
 
 COMMAND="sonar-scanner -Dsonar.host.url=$URL -Dsonar.gitlab.failure_notification_mode=exit-code"
 
+if [ -z ${SONAR_PROJECT_KEY+x} ]; then
+  SONAR_PROJECT_KEY=$CI_PROJECT_NAME
+fi
+
+if [ -z ${SONAR_PROJECT_VERSION+x} ]; then
+  SONAR_PROJECT_VERSION=$CI_BUILD_ID
+fi
+
+if [ -z ${SONAR_GITLAB_PROJECT_ID+x} ]; then
+  SONAR_GITLAB_PROJECT_ID=$CI_PROJECT_ID
+fi
+
 if [ ! -z "$SONAR_PROJECT_KEY" ]; then
   COMMAND="$COMMAND -Dsonar.projectKey=$SONAR_PROJECT_KEY"
 fi

--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ -z "$SONAR_URL" ]; then
   echo "Undefined \"SONAR_URL\" env" && exit 1

--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -68,6 +68,10 @@ if [ ! -z $SONAR_BRANCH ]; then
   COMMAND="$COMMAND -Dsonar.branch=$SONAR_BRANCH"
 fi
 
+if [ -z ${SONAR_ANALYSIS_MODE+x} ]; then
+  SONAR_ANALYSIS_MODE="preview"
+fi
+
 # `analysis by default
 if [ ! -z $SONAR_ANALYSIS_MODE ]; then
   COMMAND="$COMMAND -Dsonar.analysis.mode=$SONAR_ANALYSIS_MODE"

--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -82,4 +82,4 @@ if [ $SONAR_ANALYSIS_MODE == "publish" ]; then
   unset CI_BUILD_REF
 fi
 
-$COMMAND
+$COMMAND $1

--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -20,51 +20,51 @@ if [ -z ${SONAR_GITLAB_PROJECT_ID+x} ]; then
   SONAR_GITLAB_PROJECT_ID=$CI_PROJECT_ID
 fi
 
-if [ ! -z "$SONAR_PROJECT_KEY" ]; then
+if [ ! -z ${SONAR_PROJECT_KEY+x} ]; then
   COMMAND="$COMMAND -Dsonar.projectKey=$SONAR_PROJECT_KEY"
 fi
 
-if [ ! -z "$SONAR_TOKEN" ]; then
+if [ ! -z ${SONAR_TOKEN+x} ]; then
   COMMAND="$COMMAND -Dsonar.login=$SONAR_TOKEN"
 fi
 
-if [ ! -z "$SONAR_PROJECT_VERSION" ]; then
+if [ ! -z ${SONAR_PROJECT_VERSION+x} ]; then
   COMMAND="$COMMAND -Dsonar.projectVersion=$SONAR_PROJECT_VERSION"
 fi
 
-if [ ! -z "$SONAR_DEBUG" ]; then
+if [ ! -z ${SONAR_DEBUG+x} ]; then
   COMMAND="$COMMAND -X"
 fi
 
-if [ ! -z "$SONAR_SOURCES" ]; then
+if [ ! -z ${SONAR_SOURCES+x} ]; then
   COMMAND="$COMMAND -Dsonar.sources=$SONAR_SOURCES"
 fi
 
-if [ ! -z "$SONAR_PROFILE" ]; then
+if [ ! -z ${SONAR_PROFILE+x} ]; then
   COMMAND="$COMMAND -Dsonar.profile=$SONAR_PROFILE"
 fi
 
-if [ ! -z "$SONAR_GITLAB_PROJECT_ID" ]; then
+if [ ! -z ${SONAR_GITLAB_PROJECT_ID+x} ]; then
   COMMAND="$COMMAND -Dsonar.gitlab.project_id=$SONAR_GITLAB_PROJECT_ID"
 fi
 
-if [ ! -z "$SONAR_LANGUAGE" ]; then
+if [ ! -z ${SONAR_LANGUAGE+x} ]; then
   COMMAND="$COMMAND -Dsonar.language=$SONAR_LANGUAGE"
 fi
 
-if [ ! -z "$SONAR_ENCODING" ]; then
+if [ ! -z ${SONAR_ENCODING+x} ]; then
   COMMAND="$COMMAND -Dsonar.sourceEncoding=$SONAR_ENCODING"
 fi
 
-if [ ! -z $CI_BUILD_REF ]; then
+if [ ! -z ${CI_BUILD_REF+x} ]; then
   COMMAND="$COMMAND -Dsonar.gitlab.commit_sha=$CI_BUILD_REF"
 fi
 
-if [ ! -z $CI_BUILD_REF_NAME ]; then
+if [ ! -z ${CI_BUILD_REF_NAME+x} ]; then
   COMMAND="$COMMAND -Dsonar.gitlab.ref_name=$CI_BUILD_REF_NAME"
 fi
 
-if [ ! -z $SONAR_BRANCH ]; then
+if [ ! -z ${SONAR_BRANCH+x} ]; then
   COMMAND="$COMMAND -Dsonar.branch=$SONAR_BRANCH"
 fi
 
@@ -73,7 +73,7 @@ if [ -z ${SONAR_ANALYSIS_MODE+x} ]; then
 fi
 
 # `analysis by default
-if [ ! -z $SONAR_ANALYSIS_MODE ]; then
+if [ ! -z ${SONAR_ANALYSIS_MODE+x} ]; then
   COMMAND="$COMMAND -Dsonar.analysis.mode=$SONAR_ANALYSIS_MODE"
   if [ $SONAR_ANALYSIS_MODE="preview" ]; then
     COMMAND="$COMMAND -Dsonar.issuesReport.console.enable=true"

--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -20,10 +20,6 @@ if [ -z ${SONAR_GITLAB_PROJECT_ID+x} ]; then
   SONAR_GITLAB_PROJECT_ID=$CI_PROJECT_ID
 fi
 
-if [ ! -z ${SONAR_PROJECT_KEY+x} ]; then
-  COMMAND="$COMMAND -Dsonar.projectKey=$SONAR_PROJECT_KEY"
-fi
-
 if [ ! -z ${SONAR_TOKEN+x} ]; then
   COMMAND="$COMMAND -Dsonar.login=$SONAR_TOKEN"
 fi

--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -6,7 +6,7 @@ fi
 
 URL=$SONAR_URL
 
-COMMAND="sonar-scanner -Dsonar.host.url=$URL"
+COMMAND="sonar-scanner -Dsonar.host.url=$URL -Dsonar.gitlab.failure_notification_mode=exit-code"
 
 if [ ! -z "$SONAR_PROJECT_KEY" ]; then
   COMMAND="$COMMAND -Dsonar.projectKey=$SONAR_PROJECT_KEY"


### PR DESCRIPTION
I open the PR, but will let it open for some time, until we're sure everything works as expected.

Changes with this PR:

- Now there's no need to `unset CI_REF_NAME` when publishing, just set your mode to `publish`  #17
- Set failure_notification_mode to `exit-code` by default #13 
- Automatically define sonar variables based on gitlab ci ones (if they are not defined) #10 
- Add documentation about sonar-project.properties file #14
- Move all the `-Dsonar.gitlab.` params to the conditional block for `preview` mode, as it's the only place where gitlab params are needed.
- Created an alias of the bash file, so you can now use `gitlab-sonar-scanner` as the executable a part from the old way, `sonar-scanner-run.sh`.
- You can now pass additional params to the executable, like so:

~~~yaml
script:
- gitlab-sonar-scanner -Dsonar.custom.param=Whatever
~~~