### PR TITLE
add projectKey from env if not defined in properties

### DIFF
--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -8,6 +8,15 @@ URL=$SONAR_URL
 
 COMMAND="sonar-scanner -Dsonar.host.url=$URL"
 
+if ! grep -q sonar.projectKey "sonar-project.properties"; then
+  if [ -z ${SONAR_PROJECT_KEY+x} ]; then
+    SONAR_PROJECT_KEY=$CI_PROJECT_NAME
+  fi
+  if [ ! -z ${SONAR_PROJECT_KEY+x} ]; then
+    COMMAND="$COMMAND -Dsonar.projectKey=$SONAR_PROJECT_KEY"
+  fi
+fi
+
 if [ -z ${SONAR_PROJECT_VERSION+x} ]; then
   SONAR_PROJECT_VERSION=$CI_BUILD_ID
 fi

--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -12,9 +12,7 @@ if ! grep -q sonar.projectKey "sonar-project.properties"; then
   if [ -z ${SONAR_PROJECT_KEY+x} ]; then
     SONAR_PROJECT_KEY=$CI_PROJECT_NAME
   fi
-  if [ ! -z ${SONAR_PROJECT_KEY+x} ]; then
-    COMMAND="$COMMAND -Dsonar.projectKey=$SONAR_PROJECT_KEY"
-  fi
+  COMMAND="$COMMAND -Dsonar.projectKey=$SONAR_PROJECT_KEY"
 fi
 
 if [ -z ${SONAR_PROJECT_VERSION+x} ]; then


### PR DESCRIPTION
problems in #19 is resolved here, if the file sonar-project.properties contains projectKey variable, it won't set from Env

reason for this change is to fix backward incompatible removal of ENV variable that I was using in many CI builds which would require update on multiple projects

new code supports definition of projectKey in this order from lowest priority:
- default value $CI_PROJECT_NAME
- step env variable $SONAR_PROJECT_KEY
- projectKey in sonar-project.properties