### PR TITLE
Update sonar.branch to sonar.branch.name

### DIFF
--- a/sonar-scanner-run.sh
+++ b/sonar-scanner-run.sh
@@ -52,7 +52,7 @@ if [ ! -z ${SONAR_ENCODING+x} ]; then
 fi
 
 if [ ! -z ${SONAR_BRANCH+x} ]; then
-  COMMAND="$COMMAND -Dsonar.branch=$SONAR_BRANCH"
+  COMMAND="$COMMAND -Dsonar.branch.name=$SONAR_BRANCH"
 fi
 
 # analysis by default


### PR DESCRIPTION
When running sonar using SONAR_BRANCH parameter you will receive the following error

> WARN: The use of "sonar.branch" is deprecated and replaced by "sonar.branch.name". See https://redirect.sonarsource.com/doc/branches.html.

This commit updates the command to use the correct updated parameter