### PR TITLE
Updated sonar scanner to 3.2.0.1227

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM openjdk:8-jdk-alpine
 ## Based on this example http://stackoverflow.com/a/40612088/865222
-ENV SONAR_SCANNER_VERSION 3.0.3.778
+ENV SONAR_SCANNER_VERSION 3.2.0.1227
 
 RUN apk add --no-cache wget nodejs && \
-    wget https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip && \
+    wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip && \
     unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION} && \
-    cd /usr/bin && ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}/bin/sonar-scanner sonar-scanner && \
+    ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}/bin/sonar-scanner /usr/bin/sonar-scanner && \
     apk del wget && \
+    rm -r sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip && \
     ln -s /usr/bin/sonar-scanner-run.sh /bin/gitlab-sonar-scanner
 
 COPY sonar-scanner-run.sh /usr/bin
+CMD ["/usr/bin/sonar-scanner-run.sh"]


### PR DESCRIPTION
I took over the (dead?) PR from here https://github.com/ciricihq/gitlab-sonar-scanner/pull/33.
I changed the URL to download the sonar-scanner ZIP to the new endpoint and also removed the zip file after installation to reduce the image size.
