### PR TITLE
Revert "Upgrade sonar scanner to 3.2.0.1227"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM openjdk:8-jdk-alpine
 ## Based on this example http://stackoverflow.com/a/40612088/865222
-ENV SONAR_SCANNER_VERSION 3.2.0.1227
+ENV SONAR_SCANNER_VERSION 3.0.3.778
 
 RUN apk add --no-cache wget nodejs && \
-    wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux.zip && \
-    unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux.zip && \
+    wget https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip && \
+    unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION} && \
+    cd /usr/bin && ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}/bin/sonar-scanner sonar-scanner && \
     apk del wget && \
-    ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}-linux/bin/sonar-scanner /usr/bin/sonar-scanner && \
     ln -s /usr/bin/sonar-scanner-run.sh /bin/gitlab-sonar-scanner
 
 COPY sonar-scanner-run.sh /usr/bin


### PR DESCRIPTION
Reverts ciricihq/gitlab-sonar-scanner#35 this does not work. There's some issue with the latest version and zipped symlinks. please revert. I have to investigate more.